### PR TITLE
INSTALL.md - Add instruction to change directory

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -31,7 +31,7 @@ workon foss
 ## Install requirements
 All the requirements are mentioned in the file `requirements.txt`.
 ```bash
-pip install -r requirements.txt
+pip install -r docs/requirements.txt
 ```
 ## Local settings
 Copy the `local-settings.py` from `conffiles` to `fossWebsite` directory.


### PR DESCRIPTION
As the `requirements.txt` file is present in docs, it should be `pip install -r docs/requirements.txt`